### PR TITLE
correction for 32bit arm android system

### DIFF
--- a/packages/samba/build.sh
+++ b/packages/samba/build.sh
@@ -77,6 +77,7 @@ EOF
 
 	USING_SYSTEM_ASN1_COMPILE=1 ASN1_COMPILE=/usr/bin/asn1_compile \
 	USING_SYSTEM_COMPILE_ET=1 COMPILE_ET=/usr/bin/compile_et \
+	CFLAGS="-D__ANDROID_API__=24 -D__USE_FILE_OFFSET64=1" \
 	./buildtools/bin/waf configure \
 		--jobs="$TERMUX_MAKE_PROCESSES" \
 		--bundled-libraries='!asn1_compile,!compile_et' \


### PR DESCRIPTION
without this update on 32bit arm android samba can not serve files over 2 gigabytes
smbd -b
sizeof(off_t):  4 

with it 
smbd -b
sizeof(off_t):  8 

on 64bit system all is Ok

other docs
https://stackoverflow.com/questions/45148151/sizeofoff-t-8-when-compiling-libfuse-for-android

https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md